### PR TITLE
Fix broken template file

### DIFF
--- a/lib/template.jade
+++ b/lib/template.jade
@@ -27,7 +27,7 @@ html
 			.component
 				h2=component.name
 				.details=component.details
-				pre.html=component.html
+				pre.html=component.markup
 				pre.css=component.css
 
 


### PR DESCRIPTION
See
https://github.com/topcoat/topdoc/commit/4e3455fb60253a1541f7ee957fa467fde78f205c

The markup of a topdoc comment is handed to the template in
`component.markup` as per the new spec introduced in the referenced
commit. The default template uses `component.html` and does not show any
markup.

Updating the template to use the new spec fixes the problem and shows the markup.